### PR TITLE
Use actual tick limit for full range detection

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -203,8 +203,7 @@ def format_price(price):
 def is_full_range_position(tick_lower, tick_upper):
     """Detect if a position is full-range or near full-range"""
     # Uniswap V3/Algebra tick limits are approximately ±887,272
-    # Consider positions within 10,000 ticks of the limits as "full range"
-    TICK_LIMIT = 877272  # Slightly below actual limit for safety
+    TICK_LIMIT = 887272  # Use actual limit for detection
     
     return (tick_lower <= -TICK_LIMIT and tick_upper >= TICK_LIMIT) or (tick_upper - tick_lower) > 1700000
 


### PR DESCRIPTION
## Summary
- use actual Uniswap V3/Algebra tick limit for full-range detection logic

## Testing
- `python -m py_compile utils.py`
- `python - <<'PY'
from utils import is_full_range_position

tests = [
    (-887272, 887272),
    (-887271, 887271),
    (-886000, 886000),
    (-800000, 800000),
    (-887272, 100),
]
for lower, upper in tests:
    print(f"{lower:>8} {upper:>8} -> {is_full_range_position(lower, upper)}")
PY`


------
https://chatgpt.com/codex/tasks/task_e_68965fd614ec8325b9b5c0d9037c9e3c